### PR TITLE
Allow specification of project, fetching of latest {n} builds with --latest (--from/--to is still supported)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,17 @@ Queries jake-spec logs from jenkins and counts failed tests.
 
 Install:
 ====================
-    git clone git@github.com:johnsetzer/jake-spec-error-counter.git
+    git clone git@github.int.yammer.com/yammer/jake-spec-error-counter
     cd jake-spec-error-counter
     npm install
 
-Usage:
+Standalone Usage:
 ====================
-    node ./jake-spec-error-counter.js --host example.com --from 6277 --to 6280
+    ```node cmd --project myJenkinsProject --latest 50```
+    ```node cmd --project myJenkinsProject --from 1300 --to 1350```
+
+Jake usage from within a project:
+====================
+    ```jake spec:sauceErrorCounter["--latest 50"]```
+    ```jake spec:sauceErrorCounter["--from 1300 --to 1350"]```
+    Note: ```project``` is set within the project itself, and needed be included as an argument

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Install:
     git clone git@github.int.yammer.com/yammer/jake-spec-error-counter
     cd jake-spec-error-counter
     npm install
+    npm link
+    cd yamjs
+    npm link jake-spec-error-counter
 
 Standalone Usage:
 ====================

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Install:
 
 Standalone Usage:
 ====================
-    ```node cmd --project myJenkinsProject --latest 50```
-    ```node cmd --project myJenkinsProject --from 1300 --to 1350```
+    node cmd --project myJenkinsProject --latest 50
+    node cmd --project myJenkinsProject --from 1300 --to 1350
 
 Jake usage from within a project:
 ====================
-    ```jake spec:sauceErrorCounter["--latest 50"]```
-    ```jake spec:sauceErrorCounter["--from 1300 --to 1350"]```
+    jake spec:sauceErrorCounter["--latest 50"]
+    jake spec:sauceErrorCounter["--from 1300 --to 1350"]
     Note: ```project``` is set within the project itself, and needed be included as an argument

--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ Jake usage from within a project:
 ====================
     jake spec:sauceErrorCounter["--latest 50"]
     jake spec:sauceErrorCounter["--from 1300 --to 1350"]
-Note: ```project``` is set within the project itself, and needed be included as an argument
+Note: ```project``` is set within the project itself, and needent be included as an argument

--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ Jake usage from within a project:
 ====================
     jake spec:sauceErrorCounter["--latest 50"]
     jake spec:sauceErrorCounter["--from 1300 --to 1350"]
-    Note: ```project``` is set within the project itself, and needed be included as an argument
+Note: ```project``` is set within the project itself, and needed be included as an argument

--- a/cmd.js
+++ b/cmd.js
@@ -1,5 +1,5 @@
-var errorCounter = require('./jake-spec-error-counter.js');
+var sauceErrorCounter = require('./jake-spec-error-counter.js');
 
-errorCounter.startExternally(process.argv, function () {
+sauceErrorCounter.startExternally(process.argv, function () {
   console.log('Done.');
 });

--- a/cmd.js
+++ b/cmd.js
@@ -1,2 +1,4 @@
 var errorCounter = require('./jake-spec-error-counter.js');
-errorCounter.startExternally(process.argv);
+errorCounter.startExternally(process.argv, function () {
+  console.log('Done.');
+});

--- a/cmd.js
+++ b/cmd.js
@@ -1,0 +1,2 @@
+var errorCounter = require('./jake-spec-error-counter.js');
+errorCounter.startExternally(process.argv);

--- a/cmd.js
+++ b/cmd.js
@@ -1,4 +1,5 @@
 var errorCounter = require('./jake-spec-error-counter.js');
+
 errorCounter.startExternally(process.argv, function () {
   console.log('Done.');
 });

--- a/jake-spec-error-counter.js
+++ b/jake-spec-error-counter.js
@@ -10,7 +10,6 @@ var _ = require('underscore')
   , numFailedBuilds = 0;
 
 function parseArguments (args) {
-console.log('incoming args:', args, args instanceof Array);
   var argv = require('optimist')
     .usage('Usage: $0 --host [example.com] --project [projectname] (--latest ' +
       '[num] OR --from [num] --to [num])')
@@ -46,9 +45,6 @@ console.log('incoming args:', args, args instanceof Array);
       , from: argv.f || argv.from
       , to: argv.t || argv.to
     };
-
-console.log('argv:', argv);
-console.log('sanitizedArgs:', sanitizedArgs);
 
   return sanitizedArgs;
 }
@@ -90,7 +86,6 @@ function getLatestBuild (host, project, next) {
     , path: '/job/' + project + '/api/json'
   }
   , file = '';
-console.log('getLatestBuild host+path', host + options.path);
 
   http.get(options, function (res) {
     res.on('data', function (chunk) {
@@ -111,7 +106,7 @@ function getLog (buildNumber, host, project, cb) {
     , path: '/job/' + project + '/' + buildNumber + '/consoleText'
   }
   , file = '';
-console.log('getLog host+path', host + options.path);
+
   http.get(options, function (resp) {
     resp.on('data', function (chunk) {
       var str = chunk.toString();
@@ -144,15 +139,13 @@ function printResults () {
 }
 
 function init (sanitizedArgs, cb) {
-console.log('init\'s sanitizedArgs:', sanitizedArgs);
-  if(sanitizedArgs.to && sanitizedArgs.from) {
+  if (sanitizedArgs.to && sanitizedArgs.from) {
     fetchProjectLogs(sanitizedArgs, cb);
   } else if (sanitizedArgs.latest) {
     getLatestBuild(sanitizedArgs.host, sanitizedArgs.project, function (latestBuild) {
       sanitizedArgs.from = latestBuild - sanitizedArgs.latest + 1;// TODO: Rename latest
       sanitizedArgs.to = latestBuild;
 
-      // Pass latest build to fetchProjectLogs
       fetchProjectLogs(sanitizedArgs, cb);
     });
   } else {
@@ -160,8 +153,7 @@ console.log('init\'s sanitizedArgs:', sanitizedArgs);
   }
 
   function fetchProjectLogs (sanitizedArgs, finalCb) {
-console.log('fetchProjectLogs\'s sanitizedArgs:', sanitizedArgs);
-      var gets = []
+    var gets = []
       , from = sanitizedArgs.from
       , to = sanitizedArgs.to
       , host = sanitizedArgs.host

--- a/jake-spec-error-counter.js
+++ b/jake-spec-error-counter.js
@@ -1,5 +1,6 @@
 var argv = require('optimist')
-  .usage('Usage: $0 --host [example.com] --project [projectname] (--latest [num] OR --from [num] --to [num])')
+  .usage('Usage: $0 --host [example.com] --project [projectname] (--latest ' +
+    '[num] OR --from [num] --to [num])')
   .demand('project')
   .alias('h', 'host')
   .describe('host', 'The jenkin server\'s host ex: jenkins.domain.com')
@@ -27,13 +28,16 @@ var argv = require('optimist')
   .argv,
   _ = require('underscore'),
   async = require('async'),
-  http = require('http');
-
-var DEFAULTS = {
+  http = require('http'),
+  DEFAULTS = {
     HOST: 'jenkins.int.yammer.com'
   },
   host = argv.host || DEFAULTS.HOST,
-  project = argv.project || DEFAULTS.PROJECT;
+  project = argv.project || DEFAULTS.PROJECT,
+  browserFails = {},
+  specFails = {},
+  numBuilds = 0,
+  numFailedBuilds = 0;
 
 if(argv.latest) {
   getLatestBuild(host, project, init);
@@ -41,11 +45,6 @@ if(argv.latest) {
   // Init validates --from and --to args
   init();
 }
-
-var browserFails = {},
-  specFails = {},
-  numBuilds = 0,
-  numFailedBuilds = 0;
 
 function incrementKey (obj, key) {
   obj[key] = obj[key] ? obj[key] + 1 : 1;

--- a/jake-spec-error-counter.js
+++ b/jake-spec-error-counter.js
@@ -106,11 +106,11 @@ function getLatestBuild (host, project, next) {
 
 function getLog (buildNumber, host, project, cb) {
   var options = {
-    host: host,
-    port: 80,
-    path: '/job/' + project + '/' + buildNumber + '/consoleText' // Good test build 6277
-  },
-  file = '';
+    host: host
+    , port: 80
+    , path: '/job/' + project + '/' + buildNumber + '/consoleText'
+  }
+  , file = '';
 
   http.get(options, function (resp) {
     resp.on('data', function (chunk) {
@@ -126,9 +126,9 @@ function getLog (buildNumber, host, project, cb) {
 
 function sortAndPrint (fails) {
   _.chain(fails)
-    .pairs().sortBy(function (pair){
+    .pairs().sortBy(function (pair) {
       return pair[1] * -1;
-    }).each(function (pair){
+    }).each(function (pair) {
       console.log(pair[0] + ': ' +  pair[1]);
     });
 }

--- a/jake-spec-error-counter.js
+++ b/jake-spec-error-counter.js
@@ -144,10 +144,6 @@ function printResults () {
 
 function init (sanitizedArgs) {
 console.log('init\'s sanitizedArgs:', sanitizedArgs);
-  var from
-    , to
-    , latest;
-
   if(sanitizedArgs.to && sanitizedArgs.from) {
     fetchProjectLogs(sanitizedArgs);
   } else if (sanitizedArgs.latest) {

--- a/jake-spec-error-counter.js
+++ b/jake-spec-error-counter.js
@@ -68,9 +68,9 @@ function tallyLog (rawLog, cb) {
   if(matches) {
     matches.forEach(function (m) {
       // Same as meatches but with no g flag
-      var rematch = m.match(/.*\[(\w+)\-.*FAILED Spec\[(.*)\].*/i),
-        browser = rematch[1],
-        spec = rematch[2];
+      var rematch = m.match(/.*\[(\w+)\-.*FAILED Spec\[(.*)\].*/i)
+        , browser = rematch[1]
+        , spec = rematch[2];
 
       incrementKey(browserFails, browser);
       incrementKey(specFails, spec);
@@ -106,11 +106,11 @@ function getLatestBuild (host, project, next) {
 
 function getLog (buildNumber, host, project, cb) {
   var options = {
-    host: host,
-    port: 80,
-    path: '/job/' + project + '/' + buildNumber + '/consoleText' // Good test build 6277
-  },
-  file = '';
+    host: host
+    , port: 80
+    , path: '/job/' + project + '/' + buildNumber + '/consoleText'
+  }
+  , file = '';
 
   http.get(options, function (resp) {
     resp.on('data', function (chunk) {
@@ -126,9 +126,9 @@ function getLog (buildNumber, host, project, cb) {
 
 function sortAndPrint (fails) {
   _.chain(fails)
-    .pairs().sortBy(function (pair){
+    .pairs().sortBy(function (pair) {
       return pair[1] * -1;
-    }).each(function (pair){
+    }).each(function (pair) {
       console.log(pair[0] + ': ' +  pair[1]);
     });
 }

--- a/jake-spec-error-counter.js
+++ b/jake-spec-error-counter.js
@@ -53,8 +53,8 @@ console.log('sanitizedArgs:', sanitizedArgs);
   return sanitizedArgs;
 }
 
-function startExternally (args) {
-  init(parseArguments(args));
+function startExternally (args, cb) {
+  init(parseArguments(args), cb);
 }
 
 function incrementKey (obj, key) {
@@ -142,24 +142,27 @@ function printResults () {
   sortAndPrint(specFails);
 }
 
-function init (sanitizedArgs) {
+function init (sanitizedArgs, cb) {
 console.log('init\'s sanitizedArgs:', sanitizedArgs);
   if(sanitizedArgs.to && sanitizedArgs.from) {
-    fetchProjectLogs(sanitizedArgs);
+    fetchProjectLogs(sanitizedArgs, null, cb);
   } else if (sanitizedArgs.latest) {
     getLatestBuild(sanitizedArgs.host, sanitizedArgs.project, function (latestBuild) {
+      sanitizedArgs.from = latestBuild - sanitizedArgs.latest + 1;// TODO: Rename latest
+      sanitizedArgs.to = latestBuild;
+
       // Pass latest build to fetchProjectLogs
-      fetchProjectLogs(sanitizedArgs, latestBuild);
+      fetchProjectLogs(sanitizedArgs, latestBuild, cb);
     });
   } else {
     throw new Error('Provide (from and to) or latest');
   }
 
-  function fetchProjectLogs (sanitizedArgs, latestBuild) {
+  function fetchProjectLogs (sanitizedArgs, cb) {
 console.log('fetchProjectLogs\'s sanitizedArgs:', sanitizedArgs);
-    var gets = []
-      , from = latestBuild - sanitizedArgs.latest + 1
-      , to = latestBuild
+      var gets = []
+      , from = sanitizedArgs.from
+      , to = sanitizedArgs.to
       , host = sanitizedArgs.host
       , project = sanitizedArgs.project;
 
@@ -185,6 +188,7 @@ console.log('fetchProjectLogs\'s sanitizedArgs:', sanitizedArgs);
 
       printResults();
       console.log('\nDone.');
+      cb();
     });
   }
 }

--- a/jake-spec-error-counter.js
+++ b/jake-spec-error-counter.js
@@ -30,8 +30,7 @@ var argv = require('optimist')
   http = require('http');
 
 var DEFAULTS = {
-    HOST: 'jenkins.int.yammer.com',
-    PROJECT: 'yamjs'
+    HOST: 'jenkins.int.yammer.com'
   },
   host = argv.host || DEFAULTS.HOST,
   project = argv.project || DEFAULTS.PROJECT;

--- a/jake-spec-error-counter.js
+++ b/jake-spec-error-counter.js
@@ -14,7 +14,7 @@ var argv = require('optimist')
   .describe('to', 'The build number of the last build to scan')
   .check(function (args) {
     if (args.latest === undefined) {
-      if (args.from < 1 || args.to < 1) {
+      if (typeof args.from !== 'number' || typeof args.to !== 'number') {
         throw new Error('"--num" or "--from" and "--to" must be provided');
       }
     }

--- a/jake-spec-error-counter.js
+++ b/jake-spec-error-counter.js
@@ -138,26 +138,26 @@ function printResults () {
   sortAndPrint(specFails);
 }
 
-function init (sanitizedArgs, cb) {
-  if (sanitizedArgs.to && sanitizedArgs.from) {
-    fetchProjectLogs(sanitizedArgs, cb);
-  } else if (sanitizedArgs.latest) {
-    getLatestBuild(sanitizedArgs.host, sanitizedArgs.project, function (latestBuild) {
-      sanitizedArgs.from = latestBuild - sanitizedArgs.latest + 1;// TODO: Rename latest
-      sanitizedArgs.to = latestBuild;
+function init (args, cb) {
+  if (args.to && args.from) {
+    fetchProjectLogs(args, cb);
+  } else if (args.latest) {
+    getLatestBuild(args.host, args.project, function (latestBuild) {
+      args.from = latestBuild - args.latest + 1;
+      args.to = latestBuild;
 
-      fetchProjectLogs(sanitizedArgs, cb);
+      fetchProjectLogs(args, cb);
     });
   } else {
     throw new Error('Provide (from and to) or latest');
   }
 
-  function fetchProjectLogs (sanitizedArgs, finalCb) {
+  function fetchProjectLogs (args, cb) {
     var gets = []
-      , from = sanitizedArgs.from
-      , to = sanitizedArgs.to
-      , host = sanitizedArgs.host
-      , project = sanitizedArgs.project;
+      , from = args.from
+      , to = args.to
+      , host = args.host
+      , project = args.project;
 
     console.log('Fetching "' + project + '" from: ' + host);
     console.log('Builds:', {from: from, to: to});
@@ -180,7 +180,7 @@ function init (sanitizedArgs, cb) {
       }
 
       printResults();
-      finalCb();
+      cb();
     });
   }
 }

--- a/main.js
+++ b/main.js
@@ -2,6 +2,7 @@ var optimist = require('optimist');
 
 /**
  * Creates a jake task to display tests within the project that most frequently fail.
+ * This is a hack to make this an optional dependency for Jake.
  */
 var errorCounterFunc = function (jenkinsProject, argString) {
   var args = argString.split(' ');

--- a/main.js
+++ b/main.js
@@ -1,0 +1,22 @@
+var optimist = require('optimist');
+
+/**
+ * Creates a jake task to display tests within the project that most frequently fail.
+ */
+var errorCounter = function (jenkinsProject) {
+  namespace('spec', function () {
+    desc('Display tests that most frequently fail');
+    task('errorCounter', function () {
+      var args = optimist.parse([].slice.apply(arguments));
+
+      args.jenkinsProject = jenkinsProject;
+      console.log({args: args});
+
+
+
+      complete();
+    }, {async: true});
+  });
+};
+
+exports.errorCounter = errorCounter;

--- a/main.js
+++ b/main.js
@@ -3,16 +3,11 @@ var optimist = require('optimist');
 /**
  * Creates a jake task to display tests within the project that most frequently fail.
  */
-var sauceErrorCounterTask = function (jenkinsProject) {
-  namespace('spec', function () {
-    desc('Display tests that most frequently fail');
-    task('sauceErrorCounter', function () {
-      var args = arguments[0].split(' ');
+var errorCounterFunc = function (jenkinsProject, argString) {
+  var args = argString.split(' ');
 
-      args.push('--project', jenkinsProject);
-      require('./jake-spec-error-counter').startExternally(args, complete);
-    }, {async: true});
-  });
+  args.push('--project', jenkinsProject);
+  require('./jake-spec-error-counter').startExternally(args, complete);
 };
 
-exports.sauceErrorCounterTask = sauceErrorCounterTask;
+exports.errorCounterFunc = errorCounterFunc;

--- a/main.js
+++ b/main.js
@@ -7,10 +7,11 @@ var errorCounterTask = function (jenkinsProject) {
   namespace('spec', function () {
     desc('Display tests that most frequently fail');
     task('errorCounter', function () {
-      var args = optimist.parse([].slice.apply(arguments));
+console.log('initially passed args:', arguments);
+      var args = arguments[0].split(' ');
 
-      args.jenkinsProject = jenkinsProject;
-      console.log({args: args});
+      args.push('--project', jenkinsProject);
+console.log({'task args': args});
       require('./jake-spec-error-counter').startExternally(args, complete);
     }, {async: true});
   });

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ var optimist = require('optimist');
 /**
  * Creates a jake task to display tests within the project that most frequently fail.
  */
-var errorCounter = function (jenkinsProject) {
+var errorCounterTask = function (jenkinsProject) {
   namespace('spec', function () {
     desc('Display tests that most frequently fail');
     task('errorCounter', function () {
@@ -11,12 +11,9 @@ var errorCounter = function (jenkinsProject) {
 
       args.jenkinsProject = jenkinsProject;
       console.log({args: args});
-
-
-
-      complete();
+      require('./jake-spec-error-counter').startExternally(args, complete);
     }, {async: true});
   });
 };
 
-exports.errorCounter = errorCounter;
+exports.errorCounterTask = errorCounterTask;

--- a/main.js
+++ b/main.js
@@ -3,10 +3,10 @@ var optimist = require('optimist');
 /**
  * Creates a jake task to display tests within the project that most frequently fail.
  */
-var errorCounterTask = function (jenkinsProject) {
+var sauceErrorCounterTask = function (jenkinsProject) {
   namespace('spec', function () {
     desc('Display tests that most frequently fail');
-    task('errorCounter', function () {
+    task('sauceErrorCounter', function () {
       var args = arguments[0].split(' ');
 
       args.push('--project', jenkinsProject);
@@ -15,4 +15,4 @@ var errorCounterTask = function (jenkinsProject) {
   });
 };
 
-exports.errorCounterTask = errorCounterTask;
+exports.sauceErrorCounterTask = sauceErrorCounterTask;

--- a/main.js
+++ b/main.js
@@ -7,11 +7,9 @@ var errorCounterTask = function (jenkinsProject) {
   namespace('spec', function () {
     desc('Display tests that most frequently fail');
     task('errorCounter', function () {
-console.log('initially passed args:', arguments);
       var args = arguments[0].split(' ');
 
       args.push('--project', jenkinsProject);
-console.log({'task args': args});
       require('./jake-spec-error-counter').startExternally(args, complete);
     }, {async: true});
   });

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "author": "jsetzer",
+  "author": "Yammer",
   "name": "jake-spec-error-counter",
   "description": "Tool for downloading build logs from jenkins and counting failed tests",
   "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "engines": {
     "node": ">=0.8.8"
   },
+  "main": "main.js",
   "dependencies": {
     "async": "~0.1.22",
     "optimist": "~0.3.5",


### PR DESCRIPTION
Overview of changes:
1. Users can specify the project to pull from
2. Hostname fallback is provided in `DEFAULTS`
3. Users can now choose to pull the latest {n} builds from their project with `--latest` rather than specifying `--from` and `--to`
4. Added aliases:
   - `-h --> --host`
   - `-p --> --project`
   - `-l --> --latest`
   - `-f --> --from`
   - `-t --> --to`
